### PR TITLE
Herokusocket

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -33,7 +33,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>React App</title>
+  <title>Dice Rollerz</title>
 </head>
 
 <body>

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 // set up socket info 
 import openSocket from 'socket.io-client';
-const socket = openSocket('http://localhost:3001');
+const socket = openSocket.connect();//openSocket('http://localhost:3001');
 
 export default {
   getChatrooms: function(query) {


### PR DESCRIPTION
Removed reference to localhost as used in socket.io tutorials.
Replaced with .connect()

changed title in index.html.